### PR TITLE
Removed estimated rewards, transaction status

### DIFF
--- a/src/components/wallet/earn/Validate/AddValidator.vue
+++ b/src/components/wallet/earn/Validate/AddValidator.vue
@@ -490,21 +490,21 @@ export default class AddValidator extends Vue {
         return Big(this.$store.state.prices.usd)
     }
 
-    get estimatedReward(): Big {
-        let start = new Date(this.startDate)
-        let end = new Date(this.endDate)
-        let duration = end.getTime() - start.getTime() // in ms
+    // get estimatedReward(): Big {
+    //     let start = new Date(this.startDate)
+    //     let end = new Date(this.endDate)
+    //     let duration = end.getTime() - start.getTime() // in ms
 
-        let currentSupply = this.$store.state.Platform.currentSupply
-        let estimation = calculateStakingReward(this.stakeAmt, duration / 1000, currentSupply)
-        let res = bnToBig(estimation, 9)
+    //     let currentSupply = this.$store.state.Platform.currentSupply
+    //     let estimation = calculateStakingReward(this.stakeAmt, duration / 1000, currentSupply)
+    //     let res = bnToBig(estimation, 9)
 
-        return res
-    }
+    //     return res
+    // }
 
-    get estimatedRewardUSD() {
-        return this.estimatedReward.times(this.avaxPrice)
-    }
+    // get estimatedRewardUSD() {
+    //     return this.estimatedReward.times(this.avaxPrice)
+    // }
 
     updateFormData() {
         this.formNodeId = this.nodeId.trim()

--- a/src/components/wallet/earn/Validate/AddValidator.vue
+++ b/src/components/wallet/earn/Validate/AddValidator.vue
@@ -126,7 +126,8 @@
                             <label>{{ $t('staking.validate.summary.duration') }} *</label>
                             <p>{{ durationText }}</p>
                         </div>
-                        <div>
+                        <!-- The below code has been commented to remove Estimated rewards -->
+                        <!-- <div>
                             <label>{{ $t('staking.validate.summary.rewards') }}</label>
                             <p v-if="currency_type === 'FLR'">
                                 {{ estimatedReward.toLocaleString(2) }} FLR
@@ -134,7 +135,7 @@
                             <p v-if="currency_type === 'USD'">
                                 ${{ estimatedRewardUSD.toLocaleString(2) }} USD
                             </p>
-                        </div>
+                        </div> -->
                         <div class="submit_box">
                             <label style="margin: 8px 0 !important">
                                 * {{ $t('staking.validate.summary.warn') }}
@@ -193,7 +194,7 @@
                             </template>
                         </div>
                     </div>
-                    <div class="success_cont">
+                    <div class="success_cont" v-else>
                         <h2>{{ $t('staking.validate.success.title') }}</h2>
                         <p>{{ $t('staking.validate.success.desc') }}</p>
                         <p class="tx_id">Tx ID: {{ txId }}</p>

--- a/src/components/wallet/earn/Validate/AddValidator.vue
+++ b/src/components/wallet/earn/Validate/AddValidator.vue
@@ -126,16 +126,7 @@
                             <label>{{ $t('staking.validate.summary.duration') }} *</label>
                             <p>{{ durationText }}</p>
                         </div>
-                        <!-- The below code has been commented to remove Estimated rewards -->
-                        <!-- <div>
-                            <label>{{ $t('staking.validate.summary.rewards') }}</label>
-                            <p v-if="currency_type === 'FLR'">
-                                {{ estimatedReward.toLocaleString(2) }} FLR
-                            </p>
-                            <p v-if="currency_type === 'USD'">
-                                ${{ estimatedRewardUSD.toLocaleString(2) }} USD
-                            </p>
-                        </div> -->
+
                         <div class="submit_box">
                             <label style="margin: 8px 0 !important">
                                 * {{ $t('staking.validate.summary.warn') }}
@@ -489,22 +480,6 @@ export default class AddValidator extends Vue {
     get avaxPrice(): Big {
         return Big(this.$store.state.prices.usd)
     }
-
-    // get estimatedReward(): Big {
-    //     let start = new Date(this.startDate)
-    //     let end = new Date(this.endDate)
-    //     let duration = end.getTime() - start.getTime() // in ms
-
-    //     let currentSupply = this.$store.state.Platform.currentSupply
-    //     let estimation = calculateStakingReward(this.stakeAmt, duration / 1000, currentSupply)
-    //     let res = bnToBig(estimation, 9)
-
-    //     return res
-    // }
-
-    // get estimatedRewardUSD() {
-    //     return this.estimatedReward.times(this.avaxPrice)
-    // }
 
     updateFormData() {
         this.formNodeId = this.nodeId.trim()


### PR DESCRIPTION
1. On validator page load, we can see validation transaction is sent and a loader in the lower right end. This should not happen till the user has not initiated a transaction ( Completed, added else condition to handle the transaction response)

2. Remove estimate rewards and check USD conversion in Validator page and delegator page ( Estimated rewards has been removed in validator page and the USD conversion for max delegation is correct as per coingecko API) 